### PR TITLE
chore: release 2.11.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pycse/
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = [
 
 [project]
 name = "pycse"
-version = "2.11.1"
+version = "2.11.2"
 description = "python computations in science and engineering"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [{ name = "John Kitchin", email = "jkitchin@andrew.cmu.edu" }]
@@ -49,6 +49,12 @@ dependencies = ["numpy",
 "ipython",
 "tabulate",
 "click"]
+
+[project.urls]
+Homepage = "https://github.com/jkitchin/pycse"
+Repository = "https://github.com/jkitchin/pycse"
+Documentation = "https://kitchingroup.cheme.cmu.edu/pycse/"
+Issues = "https://github.com/jkitchin/pycse/issues"
 
 [project.scripts]
 pycse = "pycse.cli:pycse"


### PR DESCRIPTION
## Summary
- Bump version to 2.11.2
- Add `[project.urls]` so PyPI shows Homepage/Repository/Documentation/Issues (fixes clickpy not showing the GitHub repo)
- Add `.github/workflows/publish.yml` to publish to PyPI on GitHub Release via Trusted Publishing (OIDC)

## Test plan
- [ ] Merge this PR
- [ ] Create GitHub release `v2.11.2` to trigger publish workflow
- [ ] Verify build appears on https://pypi.org/project/pycse/ with the new project links

🤖 Generated with [Claude Code](https://claude.com/claude-code)